### PR TITLE
add z-index

### DIFF
--- a/src/less/sections/_header-nav.less
+++ b/src/less/sections/_header-nav.less
@@ -117,6 +117,7 @@ ul.menu-level-1>li>a {
 // при этом чтобы содержимое меню было в контейнере
 .menu-level-2-wrapper {
 	@media @desktop {
+		z-index: 2;
 		background-color: @white;
 		position: absolute;
 		left: 0px;


### PR DESCRIPTION
для обертки .menu-level-2-wrapper добавила z-index:2 , после этого перестали просвечиваться хлебные крошки , и меню стало поверх всех элементов