### PR TITLE
edit margin-bottom for text block

### DIFF
--- a/src/less/blocks/_form-contact-page.less
+++ b/src/less/blocks/_form-contact-page.less
@@ -72,9 +72,9 @@
 	font-size: 12px;
 	color: @text-light-grey;
 	padding-top: 14px;
-	padding-left: 35px;
-	padding-right: 35px;
-	padding-bottom: 35px;
+	padding-left: 30px;
+	padding-right: 30px;
+	padding-bottom: 40px;
 	p {
 		margin:0;
 		line-height: 1.2;

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -80,6 +80,7 @@
 @import "pages/account-orders";
 @import "pages/shops";
 @import "pages/article-page";
+@import "pages/contacts-page.less";
 
 // Utils - Always Last - !IMPORTANT
 @import "utils/_margins";

--- a/src/less/pages/contacts-page.less
+++ b/src/less/pages/contacts-page.less
@@ -1,0 +1,11 @@
+.section-contacts{
+	
+	@media @tablet{margin-bottom: 100px;}
+	@media @desktop{margin-bottom: 120px;}
+	@media @desktopXL{margin-bottom: 135px;}
+}
+.text-block--spacing-normal:nth-child(2){@media @tablet{margin-bottom: 0px;}}	
+
+.text-block--spacing-normal:nth-child(2) .text-block:last-child{@media @tablet{margin-bottom: 0px;}}
+
+	


### PR DESCRIPTION
Редактирование нижнего отступа основного контента до цветной полоски в футере
на мобилках -40пкс
таблетки  -100пкс
десктоп  - 120пкс
десктоп XL 135пкс

Также уменьшены отступы си=права и слева для текста политики конфиденц., чтобы на мобилках текст не выстраивался в три строки